### PR TITLE
Cacher les montures en combat

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -63,7 +63,8 @@
             "disable-inactivity": "Extend the delay before disconnection for inactivity",
             "health-bar": "Activate the display of the life bars below the fighters",
             "health-bar-shortcut": "Shortcuts for show/hide life bars",
-            "estimator": "Estimating spell damage in battle"
+            "estimator": "Estimating spell damage in battle",
+            "hide-mount": "Hide mounts during fights (beta)"
           },
           "groups": {
             "header": "Groups"

--- a/locale/es.json
+++ b/locale/es.json
@@ -61,7 +61,8 @@
             "disable-inactivity": "Extender el período de inactividad",
             "health-bar": "Visualización de barras de vida por debajo de los combatientes",
             "health-bar-shortcut": "Atajos para mostrar las barras de salud",
-            "estimator": "Hechizos de daño estimado durante el combate"
+            "estimator": "Hechizos de daño estimado durante el combate",
+            "hide-mount": "Ocultar monturas durante las peleas (beta)"
           },
           "groups": {
             "header": "Grupo"

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -63,7 +63,8 @@
             "disable-inactivity": "Prolonger le délai maximum d'inactivité",
             "estimator": "Estimation de dégats des sorts en combat",
             "health-bar": "Barres de vie en-dessous des combatants",
-            "health-bar-shortcut": "Raccourcis pour les barres de vie"
+            "health-bar-shortcut": "Raccourcis pour les barres de vie",
+            "hide-mount": "Cacher les montures pendant les combats (beta)"
           },
           "groups": {
             "header": "Groupe"

--- a/src/app/components/game/game.component.ts
+++ b/src/app/components/game/game.component.ts
@@ -131,6 +131,7 @@ export class GameComponent implements AfterViewInit {
                 if (this.jsFixes) this.jsFixes.reset();
                 if (this.hideShop) this.hideShop.reset();
                 if (this.keyboardInput) this.keyboardInput.reset();
+                if (this.hideMount) this.hideMount.reset();
         }
     }
 
@@ -169,7 +170,7 @@ export class GameComponent implements AfterViewInit {
                 this.cssOverload = new CssOverload(this.game.window);
                 this.jsFixes = new JsFixes(this.game.window);
                 this.hideShop = new HideShop(this.game.window, this.settingsService.option.general.hidden_shop);
-                this.hideMount = new HideMount(this.game.window);
+                this.hideMount = new HideMount(this.game.window, this.settingsService.option.vip.general.hidden_mount);
                 this.rapidExchange = new RapidExchange(this.game.window);
                 //this.wizAssets = new WizAssetsContainer(this.game.window, this.applicationService, this.http, this.settingsService.option.general);
                 this.keyboardInput = new KeyboardInput(this.game.window);

--- a/src/app/components/game/game.component.ts
+++ b/src/app/components/game/game.component.ts
@@ -22,6 +22,8 @@ import { RapidExchange } from "app/core/mods/rapid-exchange/rapid-exchange";
 import { HideShop } from "app/core/mods/hide-shop/hide-shop";
 import { KeyboardInput } from "app/core/mods/keyboard-input/keyboard-input";
 import { HttpClient } from '@angular/common/http';
+import { HideMount } from "app/core/mods/hide-mount/hide-mount";
+
 
 @Component({
     selector: 'component-game',
@@ -50,6 +52,7 @@ export class GameComponent implements AfterViewInit {
     private plugins: PluginsContainer;
     private hideShop: HideShop;
     private keyboardInput: KeyboardInput;
+    private hideMount: HideMount;
 
     constructor(
         private windowService: WindowService,
@@ -100,7 +103,7 @@ export class GameComponent implements AfterViewInit {
                         this.reloadMods();
                     }
                 });
-                
+
             });
 
         }
@@ -111,7 +114,7 @@ export class GameComponent implements AfterViewInit {
     public removeMods(): void {
 
         let vipStatus = 5;
-        
+
         switch (vipStatus) {
             case 5:
             case 4:
@@ -128,7 +131,7 @@ export class GameComponent implements AfterViewInit {
                 if (this.jsFixes) this.jsFixes.reset();
                 if (this.hideShop) this.hideShop.reset();
                 if (this.keyboardInput) this.keyboardInput.reset();
-        }        
+        }
     }
 
     public reloadMods(start: boolean = true): void {
@@ -166,6 +169,7 @@ export class GameComponent implements AfterViewInit {
                 this.cssOverload = new CssOverload(this.game.window);
                 this.jsFixes = new JsFixes(this.game.window);
                 this.hideShop = new HideShop(this.game.window, this.settingsService.option.general.hidden_shop);
+                this.hideMount = new HideMount(this.game.window);
                 this.rapidExchange = new RapidExchange(this.game.window);
                 //this.wizAssets = new WizAssetsContainer(this.game.window, this.applicationService, this.http, this.settingsService.option.general);
                 this.keyboardInput = new KeyboardInput(this.game.window);

--- a/src/app/core/mods/hide-mount/hide-mount.ts
+++ b/src/app/core/mods/hide-mount/hide-mount.ts
@@ -8,13 +8,12 @@ export class HideMount extends Mods
 {
     constructor (wGame: any | Window) {
         super(wGame);
-        Logger.debug('Mod HideMount - OK');
+        Logger.info(' - enable Hide-Mount');
 
         // That function shows or hides the shop button
         let toggle = () => {
             try {
                 setTimeout(() => {
-                    Logger.info('Begin Fight');
                     let actionNeeded = false;
                     if (this.wGame.actorManager.userActor.actorManager.userActor.look.subentities != null) {
                         if (this.wGame.actorManager.userActor.actorManager.userActor.look.subentities.length > 0) {
@@ -54,6 +53,6 @@ export class HideMount extends Mods
         }
 
         // Wait begin fight
-        this.on(this.wGame.dofus.connectionManager, 'GameFightNewRoundMessage', toggle);
+        this.on(this.wGame.dofus.connectionManager, 'GameFightStartMessage', toggle);
     }
 }

--- a/src/app/core/mods/hide-mount/hide-mount.ts
+++ b/src/app/core/mods/hide-mount/hide-mount.ts
@@ -1,0 +1,59 @@
+import {Mods} from "../mods";
+import {Logger} from "app/core/electron/logger.helper";
+
+/**
+ * This mod add the possibility to hide mount durring fight
+ */
+export class HideMount extends Mods
+{
+    constructor (wGame: any | Window) {
+        super(wGame);
+        Logger.debug('Mod HideMount - OK');
+
+        // That function shows or hides the shop button
+        let toggle = () => {
+            try {
+                setTimeout(() => {
+                    Logger.info('Begin Fight');
+                    let actionNeeded = false;
+                    if (this.wGame.actorManager.userActor.actorManager.userActor.look.subentities != null) {
+                        if (this.wGame.actorManager.userActor.actorManager.userActor.look.subentities.length > 0) {
+                            actionNeeded = true;
+                            this.wGame.actorManager.userActor.actorManager.userActor.look.bonesId = 1;
+                            this.wGame.actorManager.userActor.actorManager.userActor.look.skins = this.wGame.actorManager.userActor.actorManager.userActor.look.subentities["0"].subEntityLook.skins;
+                            this.wGame.actorManager.userActor.actorManager.userActor.look.scales = this.wGame.actorManager.userActor.look.subentities["0"].subEntityLook.scales;
+                            this.wGame.actorManager.userActor.actorManager.userActor.look.indexedColors = this.wGame.actorManager.userActor.look.subentities["0"].subEntityLook.indexedColors;
+                            this.wGame.actorManager.userActor.actorManager.userActor.look.subentities = null;
+                        }
+                    }
+                    for (let key in this.wGame.actorManager.actors) {
+                        if (+key > 0) {
+                            if (this.wGame.actorManager.actors[key].look.subentities != null) {
+                                actionNeeded = true;
+                                this.wGame.actorManager.actors[key].look.bonesId = 1;
+                                this.wGame.actorManager.actors[key].look.skins = this.wGame.actorManager.actors[key].look.subentities["0"].subEntityLook.skins;
+                                this.wGame.actorManager.actors[key].look.scales = this.wGame.actorManager.actors[key].look.subentities["0"].subEntityLook.scales;
+                                this.wGame.actorManager.actors[key].look.indexedColors = this.wGame.actorManager.actors[key].look.subentities["0"].subEntityLook.indexedColors;
+                                this.wGame.actorManager.actors[key].look.subentities = null;
+                            }
+                        }
+                    }
+                    Logger.debug("SKIN UPDATE DONE");
+                    if (actionNeeded) {
+                        setTimeout(() => {
+                            this.wGame.gui.mainControls._creatureModeButton.tap();
+                            setTimeout(() => {
+                                this.wGame.gui.mainControls._creatureModeButton.tap();
+                            }, (Math.random() * (500) + 1000));
+                        }, (Math.random() * (500) + 1000));
+                    }
+                }, (Math.random() * (500) + 500));
+            } catch (ex) {
+                Logger.info(ex);
+            }
+        }
+
+        // Wait begin fight
+        this.on(this.wGame.dofus.connectionManager, 'GameFightNewRoundMessage', toggle);
+    }
+}

--- a/src/app/core/mods/hide-mount/hide-mount.ts
+++ b/src/app/core/mods/hide-mount/hide-mount.ts
@@ -14,31 +14,43 @@ export class HideMount extends Mods
             Logger.info(' - enable Hide-Mount');
             let toggle = () => {
                 try {
+                    console.log(this.wGame.actorManager.userActor.actorManager.userActor.look)
                     setTimeout(() => {
                         let actionNeeded = false;
+                        // Main character
                         if (this.wGame.actorManager.userActor.actorManager.userActor.look.subentities != null) {
                             if (this.wGame.actorManager.userActor.actorManager.userActor.look.subentities.length > 0) {
                                 actionNeeded = true;
                                 this.wGame.actorManager.userActor.actorManager.userActor.look.bonesId = 1;
-                                this.wGame.actorManager.userActor.actorManager.userActor.look.skins = this.wGame.actorManager.userActor.actorManager.userActor.look.subentities["0"].subEntityLook.skins;
-                                this.wGame.actorManager.userActor.actorManager.userActor.look.scales = this.wGame.actorManager.userActor.look.subentities["0"].subEntityLook.scales;
-                                this.wGame.actorManager.userActor.actorManager.userActor.look.indexedColors = this.wGame.actorManager.userActor.look.subentities["0"].subEntityLook.indexedColors;
+                                if (this.wGame.actorManager.userActor.actorManager.userActor.look.subentities["0"].subEntityLook.skins.length > 0) {
+                                    this.wGame.actorManager.userActor.actorManager.userActor.look.skins = this.wGame.actorManager.userActor.actorManager.userActor.look.subentities["0"].subEntityLook.skins;
+                                }
+                                // Character size
+                                this.wGame.actorManager.userActor.actorManager.userActor.look.scales = [140];
+                                if (this.wGame.actorManager.userActor.look.subentities["0"].subEntityLook.indexedColors.length > 0) {
+                                    this.wGame.actorManager.userActor.actorManager.userActor.look.indexedColors = this.wGame.actorManager.userActor.look.subentities["0"].subEntityLook.indexedColors;
+                                }
                                 this.wGame.actorManager.userActor.actorManager.userActor.look.subentities = null;
                             }
                         }
+                        // Other character
                         for (let key in this.wGame.actorManager.actors) {
                             if (+key > 0) {
                                 if (this.wGame.actorManager.actors[key].look.subentities != null) {
                                     actionNeeded = true;
                                     this.wGame.actorManager.actors[key].look.bonesId = 1;
-                                    this.wGame.actorManager.actors[key].look.skins = this.wGame.actorManager.actors[key].look.subentities["0"].subEntityLook.skins;
-                                    this.wGame.actorManager.actors[key].look.scales = this.wGame.actorManager.actors[key].look.subentities["0"].subEntityLook.scales;
-                                    this.wGame.actorManager.actors[key].look.indexedColors = this.wGame.actorManager.actors[key].look.subentities["0"].subEntityLook.indexedColors;
+                                    this.wGame.actorManager.actors[key].look.scales = [140];
+                                    if (this.wGame.actorManager.actors[key].look.subentities["0"].subEntityLook.skins.length > 0) {
+                                        this.wGame.actorManager.actors[key].look.skins = this.wGame.actorManager.actors[key].look.subentities["0"].subEntityLook.skins;
+                                    }
+                                    if (this.wGame.actorManager.actors[key].look.subentities["0"].subEntityLook.indexedColors.length > 0) {
+                                        this.wGame.actorManager.actors[key].look.indexedColors = this.wGame.actorManager.actors[key].look.subentities["0"].subEntityLook.indexedColors;
+                                    }
                                     this.wGame.actorManager.actors[key].look.subentities = null;
                                 }
                             }
                         }
-                        if (actionNeeded) {
+                        if (actionNeeded && 0) {
                             setTimeout(() => {
                                 this.wGame.gui.mainControls._creatureModeButton.tap();
                                 setTimeout(() => {

--- a/src/app/core/mods/hide-mount/hide-mount.ts
+++ b/src/app/core/mods/hide-mount/hide-mount.ts
@@ -50,7 +50,7 @@ export class HideMount extends Mods
                                 }
                             }
                         }
-                        if (actionNeeded && 0) {
+                        if (actionNeeded) {
                             setTimeout(() => {
                                 this.wGame.gui.mainControls._creatureModeButton.tap();
                                 setTimeout(() => {

--- a/src/app/core/mods/hide-mount/hide-mount.ts
+++ b/src/app/core/mods/hide-mount/hide-mount.ts
@@ -14,7 +14,6 @@ export class HideMount extends Mods
             Logger.info(' - enable Hide-Mount');
             let toggle = () => {
                 try {
-                    console.log(this.wGame.actorManager.userActor.actorManager.userActor.look)
                     setTimeout(() => {
                         let actionNeeded = false;
                         // Main character
@@ -70,9 +69,5 @@ export class HideMount extends Mods
           Logger.info('- disable Hide-Mount');
         }
 
-    }
-
-    public reset() {
-        super.reset();
     }
 }

--- a/src/app/core/mods/hide-mount/hide-mount.ts
+++ b/src/app/core/mods/hide-mount/hide-mount.ts
@@ -6,53 +6,61 @@ import {Logger} from "app/core/electron/logger.helper";
  */
 export class HideMount extends Mods
 {
-    constructor (wGame: any | Window) {
+    constructor (wGame: any | Window, private hidden_mount: boolean) {
         super(wGame);
-        Logger.info(' - enable Hide-Mount');
 
-        // That function shows or hides the shop button
-        let toggle = () => {
-            try {
-                setTimeout(() => {
-                    let actionNeeded = false;
-                    if (this.wGame.actorManager.userActor.actorManager.userActor.look.subentities != null) {
-                        if (this.wGame.actorManager.userActor.actorManager.userActor.look.subentities.length > 0) {
-                            actionNeeded = true;
-                            this.wGame.actorManager.userActor.actorManager.userActor.look.bonesId = 1;
-                            this.wGame.actorManager.userActor.actorManager.userActor.look.skins = this.wGame.actorManager.userActor.actorManager.userActor.look.subentities["0"].subEntityLook.skins;
-                            this.wGame.actorManager.userActor.actorManager.userActor.look.scales = this.wGame.actorManager.userActor.look.subentities["0"].subEntityLook.scales;
-                            this.wGame.actorManager.userActor.actorManager.userActor.look.indexedColors = this.wGame.actorManager.userActor.look.subentities["0"].subEntityLook.indexedColors;
-                            this.wGame.actorManager.userActor.actorManager.userActor.look.subentities = null;
-                        }
-                    }
-                    for (let key in this.wGame.actorManager.actors) {
-                        if (+key > 0) {
-                            if (this.wGame.actorManager.actors[key].look.subentities != null) {
+        // feature active
+        if (this.hidden_mount) {
+            Logger.info(' - enable Hide-Mount');
+            let toggle = () => {
+                try {
+                    setTimeout(() => {
+                        let actionNeeded = false;
+                        if (this.wGame.actorManager.userActor.actorManager.userActor.look.subentities != null) {
+                            if (this.wGame.actorManager.userActor.actorManager.userActor.look.subentities.length > 0) {
                                 actionNeeded = true;
-                                this.wGame.actorManager.actors[key].look.bonesId = 1;
-                                this.wGame.actorManager.actors[key].look.skins = this.wGame.actorManager.actors[key].look.subentities["0"].subEntityLook.skins;
-                                this.wGame.actorManager.actors[key].look.scales = this.wGame.actorManager.actors[key].look.subentities["0"].subEntityLook.scales;
-                                this.wGame.actorManager.actors[key].look.indexedColors = this.wGame.actorManager.actors[key].look.subentities["0"].subEntityLook.indexedColors;
-                                this.wGame.actorManager.actors[key].look.subentities = null;
+                                this.wGame.actorManager.userActor.actorManager.userActor.look.bonesId = 1;
+                                this.wGame.actorManager.userActor.actorManager.userActor.look.skins = this.wGame.actorManager.userActor.actorManager.userActor.look.subentities["0"].subEntityLook.skins;
+                                this.wGame.actorManager.userActor.actorManager.userActor.look.scales = this.wGame.actorManager.userActor.look.subentities["0"].subEntityLook.scales;
+                                this.wGame.actorManager.userActor.actorManager.userActor.look.indexedColors = this.wGame.actorManager.userActor.look.subentities["0"].subEntityLook.indexedColors;
+                                this.wGame.actorManager.userActor.actorManager.userActor.look.subentities = null;
                             }
                         }
-                    }
-                    Logger.debug("SKIN UPDATE DONE");
-                    if (actionNeeded) {
-                        setTimeout(() => {
-                            this.wGame.gui.mainControls._creatureModeButton.tap();
+                        for (let key in this.wGame.actorManager.actors) {
+                            if (+key > 0) {
+                                if (this.wGame.actorManager.actors[key].look.subentities != null) {
+                                    actionNeeded = true;
+                                    this.wGame.actorManager.actors[key].look.bonesId = 1;
+                                    this.wGame.actorManager.actors[key].look.skins = this.wGame.actorManager.actors[key].look.subentities["0"].subEntityLook.skins;
+                                    this.wGame.actorManager.actors[key].look.scales = this.wGame.actorManager.actors[key].look.subentities["0"].subEntityLook.scales;
+                                    this.wGame.actorManager.actors[key].look.indexedColors = this.wGame.actorManager.actors[key].look.subentities["0"].subEntityLook.indexedColors;
+                                    this.wGame.actorManager.actors[key].look.subentities = null;
+                                }
+                            }
+                        }
+                        if (actionNeeded) {
                             setTimeout(() => {
                                 this.wGame.gui.mainControls._creatureModeButton.tap();
-                            }, (Math.random() * (500) + 1000));
-                        }, (Math.random() * (500) + 1000));
-                    }
-                }, (Math.random() * (500) + 500));
-            } catch (ex) {
-                Logger.info(ex);
-            }
+                                setTimeout(() => {
+                                    this.wGame.gui.mainControls._creatureModeButton.tap();
+                                }, (Math.random() * (500) + 500));
+                            }, (Math.random() * (500) + 500));
+                        }
+                    }, (Math.random() * (500) + 500));
+                } catch (ex) {
+                    Logger.info(ex);
+                }
+            };
+
+            // Wait begin fight
+            this.on(this.wGame.dofus.connectionManager, 'GameFightStartMessage', toggle);
+        } else {
+          Logger.info('- disable Hide-Mount');
         }
 
-        // Wait begin fight
-        this.on(this.wGame.dofus.connectionManager, 'GameFightStartMessage', toggle);
+    }
+
+    public reset() {
+        super.reset();
     }
 }

--- a/src/app/core/service/settings.service.ts
+++ b/src/app/core/service/settings.service.ts
@@ -622,6 +622,16 @@ export module Option {
             private _health_bar: boolean;
             private _health_bar_shortcut: string;
             private _estimator: boolean;
+            private _hidden_mount: boolean;
+
+            get hidden_mount(): boolean {
+                return this._hidden_mount;
+            }
+
+            set hidden_mount(hidden_mount: boolean) {
+                this.settingsProvider.write('option.vip.general.hidden_mount', hidden_mount);
+                this.hidden_mount = hidden_mount;
+            }
 
             get estimator(): boolean {
                 return this._estimator;

--- a/src/app/core/service/settings.service.ts
+++ b/src/app/core/service/settings.service.ts
@@ -630,7 +630,7 @@ export module Option {
 
             set hidden_mount(hidden_mount: boolean) {
                 this.settingsProvider.write('option.vip.general.hidden_mount', hidden_mount);
-                this.hidden_mount = hidden_mount;
+                this._hidden_mount = hidden_mount;
             }
 
             get estimator(): boolean {

--- a/src/app/core/service/settings.service.ts
+++ b/src/app/core/service/settings.service.ts
@@ -674,6 +674,7 @@ export module Option {
                 this.health_bar = this.settingsProvider.read('option.vip.general.health_bar');
                 this.health_bar_shortcut = this.settingsProvider.read('option.vip.general.health_bar_shortcut');
                 this.estimator = this.settingsProvider.read('option.vip.general.estimator');
+                this.hidden_mount = this.settingsProvider.read('option.vip.general.hidden_mount');
             }
         }
 

--- a/src/app/window/option/vip/general/general.component.html
+++ b/src/app/window/option/vip/general/general.component.html
@@ -7,6 +7,9 @@
         <div class="col-xs-12">
             <mat-checkbox color="primary" [(ngModel)]="settingsService.option.vip.general.estimator">{{ 'app.window.options.features.general.estimator' | translate }}</mat-checkbox>
         </div>
+        <div class="col-xs-12">
+            <mat-checkbox color="primary" [(ngModel)]="settingsService.option.vip.general.hidden_mount">{{ 'app.window.options.features.general.hide-mount' | translate }}</mat-checkbox>
+        </div>
 
         <div class="col-xs-12" style="margin-bottom: 10px;"> <!-- En attendant de savoir ce qu'on fait avec ce input en dessous -->
             <mat-checkbox color="primary" [(ngModel)]="settingsService.option.vip.general.health_bar">{{ 'app.window.options.features.general.health-bar' | translate }}</mat-checkbox>


### PR DESCRIPTION
Ajout d'une option pour cacher les montures et les familiers en combat.

Dans le menu "Fonctionnalite/General/Cacher les montures pendant les combats"

La modification des paramétrés requière une actualisation des personnages et a part la passage en mode créature impossible de trouver comment faire. Cela implique donc qu'a chaque début de combat (si l'option est activée) il y aura automatiquement une passage en mode créature puis un autre passage en mode normal.