### PR TITLE
[FIX] heathbar in spectator mode

### DIFF
--- a/src/app/core/mods/health-bar/healthbar.ts
+++ b/src/app/core/mods/health-bar/healthbar.ts
@@ -81,6 +81,7 @@ export class HealthBar extends Mods{
             this.setFightStart();
             this.displayOnStart();
             this.stopOnFightEnd();
+            this.stopOnFightStop();
 
 
             this.shortcutsHelper.bind(this.params.health_bar_shortcut, () => {
@@ -125,6 +126,16 @@ export class HealthBar extends Mods{
 
     private stopOnFightEnd(): void {
         this.on(this.wGame.dofus.connectionManager, 'GameFightEndMessage', (e: any) => {
+            try {
+                this.barContainer.fightEnded();
+            } catch (ex) {
+                Logger.info(ex);
+            }
+        });
+    }
+
+    private stopOnFightStop(): void {
+        this.on(this.wGame.dofus.connectionManager, 'GameFightLeaveMessage', (e: any) => {
             try {
                 this.barContainer.fightEnded();
             } catch (ex) {


### PR DESCRIPTION
Corrige le bug des barres de vie en mode spectateur : lorsque l'on quittait un combat en mode spectateur celles-ci restaient a l’écran.