### PR TITLE
CleanWindow Feature

### DIFF
--- a/electron/settings/settings-default.ts
+++ b/electron/settings/settings-default.ts
@@ -169,6 +169,7 @@ export const SettingsDefault: SettingsInterface = {
                 strict_move: false,
                 ready: false,
                 fight: false,
+                clean_window: false
             },
             multi_account: {
                 active: false,

--- a/electron/settings/settings.interface.ts
+++ b/electron/settings/settings.interface.ts
@@ -94,6 +94,7 @@ export interface SettingsInterface {
                 strict_move: boolean;
                 ready: boolean;
                 fight: boolean;
+                clean_window: boolean;
             },
             multi_account: {
                 active: boolean;

--- a/locale/en.json
+++ b/locale/en.json
@@ -113,6 +113,7 @@
           "ready": "Skip \"ready\" automatically",
           "fight": "Entry into combat automatically",
           "delay": "Time to follow (in seconds)",
+          "clean-window": "Clear popups when fight ends",
           "follow-on-map": "Follow the leader on a map",
           "strict-move": "Move on the same cell the leader moves",
           "pvp-warning": "You can't join a PvP fight automatically"

--- a/locale/es.json
+++ b/locale/es.json
@@ -111,6 +111,7 @@
           "ready": "Skip \"listo\" de forma automática",
           "fight": "La entrada automática en la lucha contra",
           "delay": "Tiempo antes de seguir (en segundos)",
+          "clean-window": "Borrar ventanas emergentes cuando la pelea termina",
           "follow-on-map": "Sigue al líder en un mapa",
           "strict-move": "Muevete sobre la celda que mueve el líder",
           "pvp-warning": "No puedes unirte a una pelea PvP automáticamente"

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -112,6 +112,7 @@
           "ready": "Passer automatique en ready",
           "fight": "Entrée dans les combats automatique",
           "delay": "Délai avant de suivre (en seconde)",
+          "clean-window": "Aucuns popups en fin de combats",
           "follow-on-map": "Suivre le leader sur une carte",
           "strict-move": "Aller sur la même case que le leader",
           "pvp-warning": "Vous ne pouvez pas rejoindre un combat PvP automatiquement"

--- a/locale/it.json
+++ b/locale/it.json
@@ -113,6 +113,7 @@
           "ready": "Salta \"ready\" automaticamente",
           "fight": "Entra in combattimento automaticamente",
           "delay": "Tempo di attesa nel seguire il capo-gruppo (in secondi)",
+          "clean-window": "Elimina i popup al termine della lotta",
           "follow-on-map": "Segui il capo-gruppo su una mappa",
           "strict-move": "Muoviti sulla stessa cella in cui si muove il capo-gruppo",
           "pvp-warning": "Non puoi entrare in un combattimento PvP automaticamente"

--- a/src/app/core/mods/auto-group/autogroup.ts
+++ b/src/app/core/mods/auto-group/autogroup.ts
@@ -55,6 +55,10 @@ export class AutoGroup extends Mods {
         if (this.params.fight)
             this.autoEnterFight(this.wGame.gui.isConnected);
 
+        // automaticly clear all popups on window
+        if (this.params.clean_window)
+            this.cleanWindow();
+
     }
 
     public autoMasterParty(skipLogin: boolean = false) {
@@ -550,6 +554,32 @@ export class AutoGroup extends Mods {
         }
 
         this.on(this.wGame.gui.playerData, "characterSelectedSuccess", onCharacterSelectedSuccess);
+    }
+
+    public cleanWindow() {
+      try {
+        this.on(this.wGame.connectionManager, 'GameFightEndMessage', () => {
+            if (!this.wGame.gui.party.currentParty) {
+                return;
+            }
+
+            const leaderId = this.wGame.gui.party.currentParty.partyLeaderId;
+            const currentPlayerId = this.wGame.gui.playerData.characterBaseInformations.id;
+
+            if (currentPlayerId !== leaderId) {
+                setTimeout(() => {
+                    for (let i = this.wGame.gui.windowsContainer._childrenList.length - 1; i >= 0; i--) {
+                        let win = this.wGame.gui.windowsContainer._childrenList[i];
+                        if (win.isVisible()) {
+                          win.close();
+                        }
+                    }
+                }, this.getRandomTime(1, 3));
+            }
+        });
+      } catch (e) {
+        Logger.info(e);
+      }
     }
 
     public autoEnterFight(skipLogin: boolean = false) {

--- a/src/app/core/service/settings.service.ts
+++ b/src/app/core/service/settings.service.ts
@@ -784,6 +784,7 @@ export module Option {
             private _follow_leader: boolean;
             private _ready: boolean;
             private _fight: boolean;
+            private _clean_window: boolean;
             private _follow_on_map: boolean;
             private _strict_move: boolean;
 
@@ -841,6 +842,15 @@ export module Option {
                 this._fight = fight;
             }
 
+            get clean_window(): boolean {
+                return this._clean_window;
+            }
+
+            set clean_window(clean_window: boolean) {
+                this.settingsProvider.write('option.vip.auto_group.clean_window', clean_window);
+                this._clean_window = clean_window;
+            }
+
             get follow_on_map(): boolean {
                 return this._follow_on_map;
             }
@@ -867,6 +877,7 @@ export module Option {
                 this.leader = this.settingsProvider.read('option.vip.auto_group.leader');
                 this.ready = this.settingsProvider.read('option.vip.auto_group.ready');
                 this.fight = this.settingsProvider.read('option.vip.auto_group.fight');
+                this.clean_window = this.settingsProvider.read('option.vip.auto_group.clean_window');
                 this.follow_on_map = this.settingsProvider.read('option.vip.auto_group.follow_on_map');
                 this.strict_move = this.settingsProvider.read('option.vip.auto_group.strict_move');
             }

--- a/src/app/window/option/vip/auto-group/auto-group.component.html
+++ b/src/app/window/option/vip/auto-group/auto-group.component.html
@@ -9,6 +9,10 @@
             <div class="col-xs-12" *ngIf="settingsService.option.vip.autogroup.fight">
                 <mat-checkbox color="primary" [(ngModel)]="settingsService.option.vip.autogroup.ready">{{'app.option.vip.auto-group.ready' | translate }}</mat-checkbox>
             </div>
+
+            <div class="col-xs-12" *ngIf="settingsService.option.vip.autogroup.fight">
+                <mat-checkbox color="primary" [(ngModel)]="settingsService.option.vip.autogroup.clean_window">{{'app.option.vip.auto-group.clean-window' | translate }}</mat-checkbox>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
This feature allow player to automatically get rid of all popus comings after each fights (Not in the "Master" character) such as Fight Results, LevelUp + anything that was open to keep a game window clean and ready to roll.