### PR TITLE
Fix/ suppression du bug du chronometre

### DIFF
--- a/src/app/core/mods/fightChronometer/fightChronometer.ts
+++ b/src/app/core/mods/fightChronometer/fightChronometer.ts
@@ -72,6 +72,10 @@ export class FightChronometer extends Mod {
                     return clearInterval(this.chronometerInterval);
                 }
 
+                if(this.chronometerContainer == null){
+                    this.chronometerContainer = this.wGame.document.querySelector("#chronometerContainer");
+                }
+        
                 this.chronometerContainer.innerHTML = new Date(chronometerTime++ * 1000).toISOString().substr(11, 8);
             }, 1000);
         } catch (ex) {


### PR DESCRIPTION
Sans raison apparente l'objet this.chronometerContainer de la classe fightChronometer passé à null et ce de manière totalement aléatoire. 
Du coup quand l'algo essayé d'utiliser la propriété innerHtml sur un objet null ce qui avais pour résultat de levé une exception.
Cette rustine en re settant l'objet en cas de nullité, à permet d'évité la levé d'exception.