### PR TITLE
Damage estimator fix

### DIFF
--- a/src/app/core/mods/damageEstimator/damageContainer.ts
+++ b/src/app/core/mods/damageEstimator/damageContainer.ts
@@ -7,43 +7,44 @@ export class DamageContainer {
     private enabled: boolean = true;
     private isInFight = false;
     private updateInterval: any;
-    private estimators: { [fighterId: number]: Estimator; } = { };
+    private estimators: { [fighterId: number]: Estimator; } = {};
 
     constructor(wGame: Window | any) {
         this.wGame = wGame;
-
-        this.container = document.createElement('div');
-        this.container.id = 'damage-estimator';
-        this.container.style.position = 'absolute';
-        this.container.style.top = '0';
-        this.container.style.left = '0';
-        this.container.style.zIndex = '1';
-        this.container.style.width = '100%';
-        this.container.style.height = '100%';
-        this.container.style.pointerEvents = 'none';
-        this.container.style.visibility = 'hidden';
+        this.container = this.createContainer();
 
         this.wGame.foreground.rootElement.appendChild(this.container);
+    }
+
+    private createContainer() {
+        const container = document.createElement('div');
+        container.id = 'damage-estimator';
+        container.style.position = 'absolute';
+        container.style.cssText = 'top: 0; left: 0; z-index: 1; width: 100%; height: 100%; pointerEvents: none; visibility: hidden';
+        return container;
     }
 
     public toggle() {
         this.enabled = !this.enabled;
     }
 
-    private show(spell:any) {
+    private show(spell: any) {
         this.displayed = true;
         this.container.style.visibility = 'visible';
+        const fighters = this.wGame.gui.fightManager.getFighters();
 
-        let fighters = this.wGame.gui.fightManager.getFighters();
-        for (let index in fighters) {
-            let fighter = this.wGame.gui.fightManager.getFighter(fighters[index]);
+        for (const key in fighters) {
+            const fighter = this.wGame.gui.fightManager.getFighter(fighters[key]);
+
             if (fighter.data.alive && fighter.id !== this.wGame.gui.playerData.characters.mainCharacterId) {
                 this.estimators[fighter.id] = new Estimator(fighter, spell, this.wGame);
             }
         }
-        /*this.updateInterval = setInterval(()=>{
+        /*
+        this.updateInterval = setInterval(() => {
             this.update(spell);
-        }, 400);*/
+        }, 400);
+        */
 
     }
 
@@ -51,6 +52,7 @@ export class DamageContainer {
         if (this.displayed) {
             this.displayed = false;
             this.container.style.visibility = 'hidden';
+
             for (let fighterId in this.estimators) {
                 this.destroyEstimator(fighterId);
             }
@@ -60,50 +62,56 @@ export class DamageContainer {
         }
     }
 
-    private update(spell:any) {
-        if (this.isInFight) {
-            let fighters = this.wGame.gui.fightManager.getFighters();
-            for (let index in fighters) {
-                let fighter = this.wGame.gui.fightManager.getFighter(fighters[index]);
-                if (fighter.data.alive && fighter.id !== this.wGame.gui.playerData.characters.mainCharacterId) {
-                    if (this.estimators[fighter.id])
-                        this.estimators[fighter.id].update(spell);
-                    else
-                        this.estimators[fighter.id] = new Estimator(fighter, spell, this.wGame);
+    private update(spell: any) {
+        if (!this.isInFight) {
+            return;
+        }
+        const fighters = this.wGame.gui.fightManager.getFighters();
+
+        for (const id of fighters) {
+            const fighter = this.wGame.gui.fightManager.getFighter(fighters[id]);
+
+            if (fighter.data.alive && fighter.id !== this.wGame.gui.playerData.characters.mainCharacterId) {
+                if (this.estimators[fighter.id]) {
+                    this.estimators[fighter.id].update(spell);
+                } else {
+                    this.estimators[fighter.id] = new Estimator(fighter, spell, this.wGame);
                 }
             }
         }
     }
 
     public destroyEstimators() {
-        this.estimators =[];
+        this.estimators = [];
         this.container.innerHTML = '';
     }
 
     public destroyEstimator(fighterId: any) {
-
         if (this.estimators[fighterId]) {
-             this.estimators[fighterId].destroy();
-             delete this.estimators[fighterId];
+            this.estimators[fighterId].destroy();
+            delete this.estimators[fighterId];
         }
     }
 
-
     public display(spell: any) {
         this.isInFight = true;
-        //if (this.enabled)
-            this.show(spell);
+        // if (this.enabled)
+        this.show(spell);
     }
 
     public fightEnded() {
         this.isInFight = false;
-        if (this.enabled)
-            this.hide();
-    }
 
+        if (this.enabled) {
+            this.hide();
+        }
+    }
 
     public destroy() {
         this.estimators = [];
-        if (this.container.parentElement) this.container.parentElement.removeChild(this.container);
+
+        if (this.container.parentElement) {
+            this.container.parentElement.removeChild(this.container);
+        }
     }
 }

--- a/src/app/core/mods/damageEstimator/estimator.ts
+++ b/src/app/core/mods/damageEstimator/estimator.ts
@@ -245,14 +245,14 @@ export class Estimator {
         isCritical: boolean,
         baseStat: number,
         fixDamages: number,
-        spellDamageModifier: [number, number],
+        spellDamageModifier: [number, number, number],
         fixResistances: number,
         criticalDamageFixedResist: number,
         percentResistances: number
     ) {
-        const [fixedDamageModifier, damageMultiplicator] = spellDamageModifier;
+        const [baseDamageModifier, fixedDamageModifier, damageMultiplicator] = spellDamageModifier;
         const power = this.getCharacterStat("damagesBonusPercent");
-        let possibleDamages = (((power * 0.8) + baseStat + 100) / 100) * baseSpellDamage + this.getCharacterStat('allDamagesBonus') + fixDamages;
+        let possibleDamages = (((power * 0.8) + baseStat + 100) / 100) * (baseSpellDamage + baseDamageModifier) + this.getCharacterStat('allDamagesBonus') + fixDamages;
 
         if (isCritical) {
             possibleDamages += this.getCharacterStat("criticalDamageBonus") - criticalDamageFixedResist;
@@ -290,6 +290,7 @@ export class Estimator {
     private getSpellDamageModifier(fighter: any) {
         let fixedDamageModifier = 0;
         let damageMultiplicator = 1;
+        let baseDamageModifier = 0;
 
         for (var buff of fighter.buffs) {
             if (buff.effect.effect.characteristic != 16) {
@@ -302,6 +303,12 @@ export class Estimator {
                 break;
             }
             switch (buff.castingSpell.spell.id) {
+                case 159: // Colère de Iop
+                case 146: // Epée du destin
+                case 167: // Flèche d'Expiation
+                case 171: // Flèche Punitive
+                    baseDamageModifier += buff.effect.value;
+                    break;
                 case 7: // Bouclier Féca
                 case 4696: // Glyphe Agressif
                 case 4684: // Flèche Analgésique
@@ -331,7 +338,7 @@ export class Estimator {
                     break;
             }
         }
-        return [Math.trunc(fixedDamageModifier), Math.trunc(damageMultiplicator)] as [number, number];
+        return [baseDamageModifier, Math.trunc(fixedDamageModifier), Math.trunc(damageMultiplicator)] as [number, number, number];
     }
 
     // TODO: Might not work when controlling a summon

--- a/src/app/core/mods/damageEstimator/estimator.ts
+++ b/src/app/core/mods/damageEstimator/estimator.ts
@@ -292,7 +292,19 @@ export class Estimator {
         let damageMultiplicator = 1;
         let baseDamageModifier = 0;
 
-        for (var buff of fighter.buffs) {
+        for (const buff of this.wGame.gui.fightManager.getFighter(this.wGame.gui.playerData.id).buffs) {
+            if (this.spell.id == buff.castingSpell.spell.id) {
+                switch (buff.castingSpell.spell.id) {
+                    case 159: // Colère de Iop
+                    case 146: // Epée du destin
+                    case 167: // Flèche d'Expiation
+                    case 171: // Flèche Punitive
+                        baseDamageModifier += buff.effect.value;
+                        break;
+                }
+            }
+        }
+        for (const buff of fighter.buffs) {
             if (buff.effect.effect.characteristic != 16) {
                 continue;
             }
@@ -303,12 +315,6 @@ export class Estimator {
                 break;
             }
             switch (buff.castingSpell.spell.id) {
-                case 159: // Colère de Iop
-                case 146: // Epée du destin
-                case 167: // Flèche d'Expiation
-                case 171: // Flèche Punitive
-                    baseDamageModifier += buff.effect.value;
-                    break;
                 case 7: // Bouclier Féca
                 case 4696: // Glyphe Agressif
                 case 4684: // Flèche Analgésique
@@ -338,7 +344,7 @@ export class Estimator {
                     break;
             }
         }
-        return [baseDamageModifier, Math.trunc(fixedDamageModifier), Math.trunc(damageMultiplicator)] as [number, number, number];
+        return [baseDamageModifier, fixedDamageModifier, damageMultiplicator] as [number, number, number];
     }
 
     // TODO: Might not work when controlling a summon


### PR DESCRIPTION
Slightly tested ingame with a poutch and it matched with what the estimator showed.

**Summary**
- Weapons damage estimation is now working properly
- the character power is multiplied by 0.8 in the damage formula
- Display critical hit damages along with the normal damages