### PR TITLE
Early Server reload

### DIFF
--- a/src/app/windows/update/update.component.ts
+++ b/src/app/windows/update/update.component.ts
@@ -183,12 +183,17 @@ export class UpdateComponent implements OnInit, OnDestroy {
             this.translate.get('app.window.update-dofus.step8').subscribe((sentence: string) => this.progressText = sentence);
             this.ipcRendererService.send('update-finished', this.localVersions);
 
-        } catch (error) {
-
+        } catch (error) { 
+                    if (this.dofusOrigin == "https://earlyproxy.touch.dofus.com/"){
+                        this.settingsService.option.general.early = false;
+                       window.location.reload();
+                    }
+                    else {
             let reason = (typeof error.message !== "undefined") ? "(" + error.message + ")" : "";
             this.translate.get('app.window.update-dofus.information.error').subscribe((sentence: string) => this.progressText = sentence + reason);
 
             this.progressError = true;
+        }
         }
     }
 


### PR DESCRIPTION
Si l'option Early est actif est que vous avez une erreur de mise a jour ( Serveur fermer ) .
L'option Early est desactiver est le jeu ce relance pour repasser sur le serveur standard.