### PR TITLE
[FIX] [V3] changelog default version selection

### DIFF
--- a/packages/renderer/src/screens/option-screen/changelog/ChangelogDialog.tsx
+++ b/packages/renderer/src/screens/option-screen/changelog/ChangelogDialog.tsx
@@ -1,6 +1,6 @@
 // import { useI18nContext } from '@lindo/i18n'
 import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Tab, Tabs, useTheme } from '@mui/material'
-import React, { memo } from 'react'
+import React, { memo, useEffect } from 'react'
 import { useChangelog } from './use-changelog'
 
 export interface ChangelogDialogProps {
@@ -14,9 +14,15 @@ export const ChangelogDialog = memo(({ open, onClose }: ChangelogDialogProps) =>
   const theme = useTheme()
   const { currentChangelog, selectedVersionIndex, versions, selectVersionIndex } = useChangelog()
 
-  const handleSelectVersion = (event: React.SyntheticEvent, index: number) => {
+  const handleSelectVersion = (_event: React.SyntheticEvent | undefined, index: number) => {
     selectVersionIndex(index)
   }
+
+  useEffect(() => {
+    if (open) {
+      handleSelectVersion(undefined, 0)
+    }
+  }, [open])
 
   return (
     <Dialog open={open} onClose={onClose} fullScreen>


### PR DESCRIPTION
**Bug:**
When opening changelog, no version was selected.

**Fix:**
The last version is now selected by default.