### PR TITLE
Prevent user from using invalid electron accelerators for tab switching

### DIFF
--- a/packages/i18n/en/index.ts
+++ b/packages/i18n/en/index.ts
@@ -190,7 +190,8 @@ const en: BaseTranslation = {
         monsterTooltip: 'Show/hide monsters tooltip'
       },
       information:
-        'You can use special keys CTRL, SHIFT, SPACE, ALT/CMD You can specify your shortcut by pressing the desired keys at the same time after selecting the input'
+        'You can use special keys CTRL, SHIFT, SPACE, ALT/CMD You can specify your shortcut by pressing the desired keys at the same time after selecting the input',
+      error: 'This shortcut key cannot be used.'
     },
     features: {
       title: 'Features',

--- a/packages/i18n/es/index.ts
+++ b/packages/i18n/es/index.ts
@@ -191,7 +191,8 @@ const es: Translation = {
         monsterTooltip: 'Mostrar/ocultar información del grupo de monstruos'
       },
       information:
-        'Puede usar las teclas CTRL/CMD, MAYÚS, ESPACIO, ALT. Para ingresar sus accesos directos, presione la combinación de teclas deseada en el campo.'
+        'Puede usar las teclas CTRL/CMD, MAYÚS, ESPACIO, ALT. Para ingresar sus accesos directos, presione la combinación de teclas deseada en el campo.',
+      error: 'No se puede utilizar esta tecla de acceso directo.'
     },
     features: {
       title: 'Características',

--- a/packages/i18n/fr/index.ts
+++ b/packages/i18n/fr/index.ts
@@ -191,7 +191,8 @@ const fr: Translation = {
         monsterTooltip: 'Afficher/Cacher les informations des groupes de monstres'
       },
       information:
-        'Vous pouvez utiliser les touches CTRL/CMD, SHIFT, ESPACE, ALT. Pour rentrer vos raccourcis pressez la combinaison de touche souhaitée dans le champ.'
+        'Vous pouvez utiliser les touches CTRL/CMD, SHIFT, ESPACE, ALT. Pour rentrer vos raccourcis pressez la combinaison de touche souhaitée dans le champ.',
+      error: 'Cette touche de raccourci ne peut pas être utilisée.'
     },
     features: {
       title: 'Fonctionnalités',

--- a/packages/i18n/i18n-types.ts
+++ b/packages/i18n/i18n-types.ts
@@ -606,6 +606,10 @@ type RootTranslation = {
 			 * You can use special keys CTRL, SHIFT, SPACE, ALT/CMD You can specify your shortcut by pressing the desired keys at the same time after selecting the input
 			 */
 			information: string
+			/**
+			 * This shortcut key cannot be used.
+			 */
+			error: string
 		}
 		features: {
 			/**
@@ -1673,6 +1677,10 @@ export type TranslationFunctions = {
 			 * You can use special keys CTRL, SHIFT, SPACE, ALT/CMD You can specify your shortcut by pressing the desired keys at the same time after selecting the input
 			 */
 			information: () => LocalizedString
+			/**
+			 * This shortcut key cannot be used.
+			 */
+			error: () => LocalizedString
 		}
 		features: {
 			/**

--- a/packages/renderer/src/screens/option-screen/shortcuts/OptionShortcuts.tsx
+++ b/packages/renderer/src/screens/option-screen/shortcuts/OptionShortcuts.tsx
@@ -40,12 +40,14 @@ export const OptionShortcuts = () => {
                         label={LL.option.shortcuts.application.newWindow()}
                         value={hotkeyStore.window.newWindow}
                         onChange={hotkeyStore.window.setNewWindow}
+                        restrictKeyCode
                       />
                       <ShortcutInput
                         id='new-tab'
                         label={LL.option.shortcuts.application.newTab()}
                         value={hotkeyStore.window.newTab}
                         onChange={hotkeyStore.window.setNewTab}
+                        restrictKeyCode
                       />
                     </Stack>
                   </Grid>
@@ -56,12 +58,14 @@ export const OptionShortcuts = () => {
                         label={LL.option.shortcuts.application.nextTab()}
                         value={hotkeyStore.window.nextTab}
                         onChange={hotkeyStore.window.setNextTab}
+                        restrictKeyCode
                       />
                       <ShortcutInput
                         id='previous-tab'
                         label={LL.option.shortcuts.application.prevTab()}
                         value={hotkeyStore.window.prevTab}
                         onChange={hotkeyStore.window.setPrevTab}
+                        restrictKeyCode
                       />
                     </Stack>
                   </Grid>
@@ -74,6 +78,7 @@ export const OptionShortcuts = () => {
                           label={LL.option.shortcuts.application.tab({ x: i + 1 })}
                           value={hotkeyStore.window.tabs[i]}
                           onChange={(shortcut) => hotkeyStore.window.setTab(shortcut, i)}
+                          restrictKeyCode
                         />
                       ))}
                     </Stack>
@@ -87,6 +92,7 @@ export const OptionShortcuts = () => {
                           label={LL.option.shortcuts.application.tab({ x: i + 1 })}
                           value={hotkeyStore.window.tabs[i]}
                           onChange={(shortcut) => hotkeyStore.window.setTab(shortcut, i)}
+                          restrictKeyCode
                         />
                       ))}
                     </Stack>

--- a/packages/renderer/src/screens/option-screen/shortcuts/ShortcutInput.tsx
+++ b/packages/renderer/src/screens/option-screen/shortcuts/ShortcutInput.tsx
@@ -10,6 +10,10 @@ const KEY_MAPPER = {
   ' ': 'Space'
 }
 
+const MODIFIERS = /^(Meta|CommandOrControl|CmdOrCtrl|Command|Cmd|Control|Ctrl|AltGr|Option|Alt|Shift|Super)$/i
+const KEY_CODES =
+  /^(Num[0-9]|Plus|Space|Tab|Backspace|Delete|Insert|Return|Enter|Up|Down|Left|Right|Home|End|PageUp|PageDown|Escape|Esc|VolumeUp|VolumeDown|VolumeMute|MediaNextTrack|MediaPreviousTrack|MediaStop|MediaPlayPause|PrintScreen|F24|F23|F22|F21|F20|F19|F18|F17|F16|F15|F14|F13|F12|F11|F10|F9|F8|F7|F6|F5|F4|F3|F2|F1|[0-9A-Z)!@#$%^&*(:<_>?~{|}";=,\-./`[\\\]'])$/i
+
 export interface ShortcutInputProps {
   id: string
   label: string
@@ -47,13 +51,9 @@ export const ShortcutInput = memo<ShortcutInputProps>(({ id, label, value, onCha
     }
 
     // prevent using modifier key as shortcut
-    switch (event.key) {
-      case 'Meta':
-      case 'Shift':
-      case 'Ctrl':
-      case 'Alt':
-        return
-    }
+    if (MODIFIERS.test(event.key)) return
+    // prevent using invalid electron accelerator for tab switching
+    if (id === 'new-window' || id.includes('tab')) if (!KEY_CODES.test(event.key)) return
 
     const normalizeKey = Object.hasOwn(KEY_MAPPER, event.key)
       ? KEY_MAPPER[event.key as never]


### PR DESCRIPTION
An issue with registering some invalid characters shortcut using [@hfelix/electron-localshortcut](https://github.com/fxha/electron-localshortcut) for tab switching has been fixed using regex validation only for tab switching.

Since we only use [@hfelix/electron-localshortcut](https://github.com/fxha/electron-localshortcut) for tab switching, refer to [this](https://github.com/riaddaima/lindo/commit/7bcaf0787eaf9ecb6ddd51fe6647cd2eb674fc33), we need to check if the shortcut input is for the application tab first, because we do not want to disable those working characters for spells, interface, etc.

I thought about using [isValidElectronAccelerator(accelerator)](https://github.com/fxha/electron-localshortcut/blob/37b33e4ec098a39165c493b9ef8152e4d3113250/src/convert-accelerator.js#L149) but ShortcutInput.tsx is not in the electron context so [this ](https://github.com/fxha/electron-localshortcut/blob/37b33e4ec098a39165c493b9ef8152e4d3113250/src/convert-accelerator.js#L7) throws an error.

### Regex source from: https://github.com/fxha/electron-localshortcut/blob/master/src/convert-accelerator.js#L10