### PR TITLE
Auto-updater Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,9 @@ jobs:
           path: |
             release/${{ steps.extract_version.outputs.version }}/Lindo-${{ steps.extract_version.outputs.version }}-win.zip
             release/${{ steps.extract_version.outputs.version }}/Lindo-${{ steps.extract_version.outputs.version }}-ia32-win.zip
-            release/${{ steps.extract_version.outputs.version }}/Lindo ${{ steps.extract_version.outputs.version }}.exe
-            release/${{ steps.extract_version.outputs.version }}/Lindo Setup ${{ steps.extract_version.outputs.version }}.exe
+            release/${{ steps.extract_version.outputs.version }}/Lindo-${{ steps.extract_version.outputs.version }}.exe
+            release/${{ steps.extract_version.outputs.version }}/Lindo-Setup-${{ steps.extract_version.outputs.version }}.exe
+            release/${{ steps.extract_version.outputs.version }}/latest.yml
       
       - name: Upload MacOS artifacts
         uses: actions/upload-artifact@v2
@@ -99,10 +100,11 @@ jobs:
           automatic_release_tag: "v${{ steps.extract_version.outputs.version }}"
           title: "v${{ steps.extract_version.outputs.version }}"
           files: |
-            windows/Lindo ${{ steps.extract_version.outputs.version }}.exe
-            windows/Lindo Setup ${{ steps.extract_version.outputs.version }}.exe
+            windows/Lindo-${{ steps.extract_version.outputs.version }}.exe
+            windows/Lindo-Setup-${{ steps.extract_version.outputs.version }}.exe
             windows/Lindo-${{ steps.extract_version.outputs.version }}-win.zip
             windows/Lindo-${{ steps.extract_version.outputs.version }}-ia32-win.zip
+            windows/latest.yml
             linux/Lindo-${{ steps.extract_version.outputs.version }}.AppImage
             linux/Lindo-${{ steps.extract_version.outputs.version }}-arm64.AppImage
             linux/lindo-${{ steps.extract_version.outputs.version }}.tar.gz
@@ -111,4 +113,3 @@ jobs:
             linux/lindo_${{ steps.extract_version.outputs.version }}_arm64.deb
             macos/Lindo-${{ steps.extract_version.outputs.version }}.dmg
             macos/Lindo-${{ steps.extract_version.outputs.version }}-arm64.dmg
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,4 +116,4 @@ jobs:
             linux/latest-linux.yml
             macos/Lindo-${{ steps.extract_version.outputs.version }}.dmg
             macos/Lindo-${{ steps.extract_version.outputs.version }}-arm64.dmg
-            macos/latest-linux.yml
+            macos/latest-mac.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
           path: |
             release/${{ steps.extract_version.outputs.version }}/Lindo-${{ steps.extract_version.outputs.version }}.dmg
             release/${{ steps.extract_version.outputs.version }}/Lindo-${{ steps.extract_version.outputs.version }}-arm64.dmg
+            release/${{ steps.extract_version.outputs.version }}/latest-mac.yml
 
       - name: Upload Linux artifacts
         uses: actions/upload-artifact@v2
@@ -72,6 +73,7 @@ jobs:
             release/${{ steps.extract_version.outputs.version }}/lindo-${{ steps.extract_version.outputs.version }}-arm64.tar.gz
             release/${{ steps.extract_version.outputs.version }}/lindo_${{ steps.extract_version.outputs.version }}_amd64.deb
             release/${{ steps.extract_version.outputs.version }}/lindo_${{ steps.extract_version.outputs.version }}_arm64.deb
+            release/${{ steps.extract_version.outputs.version }}/latest-linux.yml
 
   create-release:
     name: "Upload Release"
@@ -111,5 +113,7 @@ jobs:
             linux/lindo-${{ steps.extract_version.outputs.version }}-arm64.tar.gz
             linux/lindo_${{ steps.extract_version.outputs.version }}_amd64.deb
             linux/lindo_${{ steps.extract_version.outputs.version }}_arm64.deb
+            linux/latest-linux.yml
             macos/Lindo-${{ steps.extract_version.outputs.version }}.dmg
             macos/Lindo-${{ steps.extract_version.outputs.version }}-arm64.dmg
+            macos/latest-linux.yml

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -39,10 +39,14 @@
     ]
   },
   "nsis": {
+    "artifactName": "${productName}-Setup-${version}.${ext}",
     "oneClick": false,
     "perMachine": false,
     "allowToChangeInstallationDirectory": true,
     "deleteAppDataOnUninstall": false
+  },
+  "portable": {
+    "artifactName": "${productName}-${version}.${ext}"
   },
   "afterPack": "./scripts/afterPackHook.js",
   "mac": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "crypto-js": "^4.1.1",
     "custom-electron-titlebar": "^4.1.0",
     "electron-store": "^8.0.1",
+    "electron-updater": "^5.2.1",
     "eventemitter3": "^4.0.7",
     "express": "^4.18.1",
     "firebase": "^9.9.2",

--- a/packages/main/updater/app-updater.ts
+++ b/packages/main/updater/app-updater.ts
@@ -1,5 +1,5 @@
 import { RootStore } from '@lindo/shared'
-import { app, dialog } from 'electron'
+import { app, dialog, shell } from 'electron'
 import { logger } from '../logger'
 import { I18n } from '../utils'
 import { autoUpdater, UpdateInfo } from 'electron-updater'
@@ -35,7 +35,7 @@ export class AppUpdater {
 
     autoUpdater.on('update-available', ({ version }: UpdateInfo) => {
       logger.info('appUpdater -> An Update is available v' + version)
-      this._showUpdateDialog(version, false)
+      this._showUpdateDialog(version, true)
     })
 
     autoUpdater.on('update-not-available', () => {
@@ -74,10 +74,24 @@ export class AppUpdater {
       })
       .then((returnValue) => {
         if (returnValue.response === 0) {
-          autoUpdater.downloadUpdate()
+          if (process.platform === 'win32') {
+            this._handleWindows()
+          } else {
+            this._handleOther()
+          }
         } else {
           logger.info('appUpdater -> App update ignored.')
         }
       })
+  }
+
+  private _handleWindows() {
+    autoUpdater.downloadUpdate()
+  }
+
+  private _handleOther() {
+    logger.info('appUpdater -> Redirected to app download page.')
+    shell.openExternal('https://github.com/prixe/lindo/releases/latest')
+    app.exit()
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1568,6 +1568,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
+"@types/semver@^7.3.6":
+  version "7.3.12"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.12.tgz#920447fdd78d76b19de0438b7f60df3c4a80bf1c"
+  integrity sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==
+
 "@types/serve-static@*":
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.0.tgz#c7930ff61afb334e121a9da780aac0d9b8f34155"
@@ -3029,6 +3034,21 @@ electron-to-chromium@^1.4.202:
   version "1.4.211"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.211.tgz#afaa8b58313807501312d598d99b953568d60f91"
   integrity sha512-BZSbMpyFQU0KBJ1JG26XGeFI3i4op+qOYGxftmZXFZoHkhLgsSv4DHDJfl8ogII3hIuzGt51PaZ195OVu0yJ9A==
+
+electron-updater@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/electron-updater/-/electron-updater-5.2.1.tgz#297795e6e8ad9179c7ae2738a7b67cf0a5022be1"
+  integrity sha512-OQZVIvqcK8j03HjT07uVPgvguP/r8RY2wZcwCM26+fcDOjtrm01Dfz3G8Eru+69znbrR+F9pDzr98ewMavBrWQ==
+  dependencies:
+    "@types/semver" "^7.3.6"
+    builder-util-runtime "9.0.3"
+    fs-extra "^10.0.0"
+    js-yaml "^4.1.0"
+    lazy-val "^1.0.5"
+    lodash.escaperegexp "^4.1.2"
+    lodash.isequal "^4.5.0"
+    semver "^7.3.5"
+    typed-emitter "^2.1.0"
 
 electron@^19.0.1:
   version "19.0.11"
@@ -4766,6 +4786,16 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
+
+lodash.escaperegexp@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
+  integrity sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
 
 lodash.merge@^4.6.2:
   version "4.6.2"


### PR DESCRIPTION
## This PR has only been tested for windows.
This PR resolves the issue #239. I used [electron-updater](https://www.electron.build/auto-update.html) to make this feature.

I had some challenge making this PR, since the whole thing takes a lot of time to test. You have to release and make another release to test it correctly so it wasn't easy to debug. Also I wasted a lot of time trying to log what was happening until I understood that I needed to specify the logger for `autoUpdater`.

I faced another issue regarding the assets where the nsis generates a `Lindo Setup vX.X.exe` with spaces in its name, and latest.yml refers to this generated setup with - instead of _spaces_. But when doing a release, the github action replaces the _spaces_ with dots. So I had to specify the `artifactName` explicitly in `electron-builder.json` to match the correct setup to download.

The `latest.yml` generated during the build is the one responsible for knowing which release it should download. So when it runs the app, it checks the most recent `latest.yml` I believe and download the most up-to-date version of Lindo.

### Updating is not mandatory for the players for now, `autoUpdater.autoDownload = false`. I prefer to give the choice, but they will have the popup message appear as long as there is an update available.

