### PR TITLE
Unique user agent per window & Minimal interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lindo",
   "productName": "Lindo",
   "private": true,
-  "version": "3.0.0-rc.12",
+  "version": "3.0.0-rc.13",
   "description": "Play Dofus Touch on Linux/OS X/Window",
   "homepage": "https://github.com/prixe/lindo",
   "author": "Zenoxs <amaury.civier@gmail.com>",

--- a/packages/i18n/en/index.ts
+++ b/packages/i18n/en/index.ts
@@ -123,6 +123,7 @@ const en: BaseTranslation = {
       language: 'Language',
       resolution: 'Resolution',
       fullScreen: 'Full screen',
+      minimalInterface: 'Minimal interface',
       hideTab: 'Hide the multi-account tab bar',
       localContent: 'Enable local map download (beta)',
       soundFocus: 'Enable game sound only on foreground window',

--- a/packages/i18n/es/index.ts
+++ b/packages/i18n/es/index.ts
@@ -39,7 +39,6 @@ const es: Translation = {
         zoomOut: 'Alejar zoom',
         resetZoom: 'Reiniciar zoom',
         fullScreen: 'Pantalla completa',
-        minimalInterface: 'interfaz mínima'
       },
       infos: {
         title: '?',

--- a/packages/i18n/es/index.ts
+++ b/packages/i18n/es/index.ts
@@ -38,7 +38,8 @@ const es: Translation = {
         zoomIn: 'Acercar zoom',
         zoomOut: 'Alejar zoom',
         resetZoom: 'Reiniciar zoom',
-        fullScreen: 'Pantalla completa'
+        fullScreen: 'Pantalla completa',
+        minimalInterface: 'interfaz mínima'
       },
       infos: {
         title: '?',
@@ -124,6 +125,7 @@ const es: Translation = {
       language: 'Lenguaje',
       resolution: 'Resolución',
       fullScreen: 'Pantalla completa',
+      minimalInterface: 'interfaz mínima',
       hideTab: 'Ocultar la barra de pestañas multicuenta',
       localContent: 'Habilitar la descarga de mapas locales (beta)',
       soundFocus: 'Sonido del juego solo en la ventana de primer plano',

--- a/packages/i18n/fr/index.ts
+++ b/packages/i18n/fr/index.ts
@@ -124,6 +124,7 @@ const fr: Translation = {
       language: 'Langue',
       resolution: 'Résolution',
       fullScreen: 'Activer le mode plein écran',
+      minimalInterface: 'Interface minimal',
       hideTab: "Masquer la barre d'onglets multi-compte",
       localContent: 'Activer le téléchargement local des cartes (beta)',
       soundFocus: 'Activer le son du jeu uniquement sur la fenêtre au premier plan',

--- a/packages/i18n/fr/index.ts
+++ b/packages/i18n/fr/index.ts
@@ -124,7 +124,7 @@ const fr: Translation = {
       language: 'Langue',
       resolution: 'Résolution',
       fullScreen: 'Activer le mode plein écran',
-      minimalInterface: 'Interface minimal',
+      minimalInterface: 'Interface minimale',
       hideTab: "Masquer la barre d'onglets multi-compte",
       localContent: 'Activer le téléchargement local des cartes (beta)',
       soundFocus: 'Activer le son du jeu uniquement sur la fenêtre au premier plan',

--- a/packages/i18n/i18n-types.ts
+++ b/packages/i18n/i18n-types.ts
@@ -378,6 +378,10 @@ type RootTranslation = {
 			 */
 			fullScreen: string
 			/**
+			 * Minimal interface
+			 */
+			minimalInterface: string
+			/**
 			 * Hide the multi-account tab bar
 			 */
 			hideTab: string
@@ -1451,6 +1455,10 @@ export type TranslationFunctions = {
 			 * Full screen
 			 */
 			fullScreen: () => LocalizedString
+			/**
+			 * Minimal interface
+			 */
+			minimalInterface: () => LocalizedString
 			/**
 			 * Hide the multi-account tab bar
 			 */

--- a/packages/main/application.ts
+++ b/packages/main/application.ts
@@ -150,6 +150,18 @@ export class Application {
     } else {
       this.createGameWindow()
     }
+    // Observe changes in minimalInterface option
+    observe(
+      this._rootStore.optionStore.window,
+      'minimalInterface',
+      (change) => {
+          if(change.type === 'update'){
+              for (const gWindow of this._gWindows) {
+                  gWindow._win.reload();
+              }
+          }
+      }
+  )
     observe(
       this._rootStore.optionStore.window,
       'audioMuted',

--- a/packages/main/utils/user-agent.ts
+++ b/packages/main/utils/user-agent.ts
@@ -1,39 +1,48 @@
 import crypto from 'crypto'
-import userAgents from './user-agents.json'
+import userAgentsJson from './user-agents.json';
 import ElectronStore from 'electron-store'
 
+
+const USER_AGENT_ARRAY_LENGTH = 16;
+interface UserAgent {
+  ua: string;
+  platformVersion: string;
+  model: string;
+}
+const userAgents: UserAgent[] = userAgentsJson as UserAgent[];
 interface UserAgentStore {
-  userAgent: {
-    ua: string
-    maxAge: string
+  maxAge: string;
+  userAgents: UserAgent[]
+}
+
+const _getUA = (): UserAgent[] => {
+  const maxIndex = userAgents.length - 1;
+  const index = crypto.randomInt(0, maxIndex - USER_AGENT_ARRAY_LENGTH);
+  return userAgents.slice(index, index + USER_AGENT_ARRAY_LENGTH);
+}
+
+export const generateUserArgent = async (appVersion: string, index: number = 0) => {
+  if (index < 0 || index > userAgents.length - 1) {
+    index = 0;
   }
-}
-
-const _getUA = (): string => {
-  const maxIndex = userAgents.length - 1
-  const index = crypto.randomInt(0, maxIndex)
-
-  return userAgents[index]
-}
-
-export const generateUserArgent = async (appVersion: string) => {
   const storage = new ElectronStore<UserAgentStore>()
   const now = new Date()
 
-  let ua: string
-  if (!storage.get('userAgent') || new Date(storage.get('userAgent').maxAge) < now) {
-    ua = _getUA()
-
+  let uas: UserAgent[]
+  if (!storage.get('userAgents') || new Date(storage.get('maxAge')) < now) {
+    uas = _getUA();
     const expireDay = crypto.randomInt(10, 360)
     const maxAge = new Date(now.setDate(now.getDate() + expireDay)).toString()
-
-    storage.set('userAgent', {
-      ua,
-      maxAge
-    } as UserAgentStore['userAgent'])
+    storage.set('userAgents', uas)
+    storage.set('maxAge', maxAge)
   } else {
-    ua = storage.get('userAgent').ua
+    uas = storage.get('userAgents')
   }
+  return uas[index].ua + ' DofusTouch Client ' + appVersion
+}
 
-  return ua + ' DofusTouch Client ' + appVersion
+export const userAgentFromIndex = (index: number = 0): UserAgent => {
+  const storage = new ElectronStore<UserAgentStore>()
+  const uas = storage.get('userAgents');
+  return uas[index]
 }

--- a/packages/main/windows/game-window.ts
+++ b/packages/main/windows/game-window.ts
@@ -14,7 +14,7 @@ type GameWindowEvents = {
   close: (event: Event) => void
 }
 export class GameWindow extends (EventEmitter as new () => TypedEmitter<GameWindowEvents>) {
-  private readonly _win: BrowserWindow
+  readonly _win: BrowserWindow
   private readonly _store: RootStore
   private readonly _teamWindow?: GameTeamWindow
   private readonly _team?: GameTeam
@@ -76,9 +76,7 @@ export class GameWindow extends (EventEmitter as new () => TypedEmitter<GameWind
       }
     })
     const currIndex = JSON.parse(JSON.stringify(this))["_index"];
-    console.log("currIndex ", currIndex);
     const ua_ch = userAgentFromIndex(currIndex);
-    console.log("ua_ch ", ua_ch);
     // when Referer is send to the ankama server, the request can be blocked
     this._win.webContents.session.webRequest.onBeforeSendHeaders(
       {

--- a/packages/renderer/src/screens/main-screen/game-screen/use-game-manager.ts
+++ b/packages/renderer/src/screens/main-screen/game-screen/use-game-manager.ts
@@ -1,4 +1,4 @@
-import { Game, RootStore } from '@/store'
+import { Game, RootStore, useStores } from '@/store'
 import { MODS, NotificationsMod } from '@/mods'
 import { Mod } from '@/mods/mod'
 import { DofusWindow } from '@/dofus-window'
@@ -22,7 +22,7 @@ export const useGameManager = ({ game, rootStore, LL }: GameManagerProps) => {
   const windowResized = useRef<Subject<void>>(new Subject())
   let backupMaxZoom: number | undefined
   const disposers = useRef<Array<() => void>>([])
-
+  const { optionStore } = useStores();
   const destroyMods = () => {
     window.lindoAPI.logger.info('destroy mods')()
     for (const mod of mods.current) {
@@ -59,7 +59,7 @@ export const useGameManager = ({ game, rootStore, LL }: GameManagerProps) => {
       const onWindowResized = windowResized.current.pipe(debounceTime(300)).subscribe(() => {
         try {
           dWindow.gui._resizeUi()
-        } catch (e) {}
+        } catch (e) { }
         fixMaxZoom()
       })
 
@@ -105,7 +105,11 @@ export const useGameManager = ({ game, rootStore, LL }: GameManagerProps) => {
         })
         char.rootElement.style.width = '100%'
         char.rootElement.style.height = '100%'
-
+        if (optionStore.window.minimalInterface) {
+          char.canvas.rootElement.style.height = '30px'
+          char.canvas.rootElement.style.marginLeft = '2px'
+          char.canvas.rootElement.style.aspectRatio = '2 / 1'
+        }
         game.setCharacterIcon(char.rootElement)
         startMods()
         fixMaxZoom()

--- a/packages/renderer/src/screens/main-screen/side-bar/SideBar.tsx
+++ b/packages/renderer/src/screens/main-screen/side-bar/SideBar.tsx
@@ -24,16 +24,6 @@ import { Game, useStores } from '@/store'
 import { TabAdd, TabGame } from './tab'
 import { Box, IconButton } from '@mui/material'
 
-const SideBarContainer = styled('div')(({ theme }) => ({
-  backgroundColor: theme.palette.background.paper,
-  overflowX: 'hidden',
-  overflowY: 'auto',
-  width: '71px',
-  display: 'flex',
-  alignItems: 'center',
-  flexDirection: 'column'
-}))
-
 const SortableItem = ({ game }: { game: Game }) => {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: game.id })
 
@@ -49,7 +39,35 @@ const SortableItem = ({ game }: { game: Game }) => {
   )
 }
 export const SideBar = () => {
-  const { gameStore } = useStores()
+  const { gameStore, optionStore } = useStores()
+  const SideBarContainer = styled('div')(({ theme }) => (
+    optionStore.window.minimalInterface ?
+      {
+        backgroundColor: "#ffffff00",
+        overflowX: 'hidden',
+        overflowY: 'hidden',
+        width: 'auto',
+        height: '40px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexDirection: 'row',
+        position: 'fixed',
+        left: '50%',
+        transform: "translateX(-50%)",
+        top: '32px',
+        zIndex: '2',
+      } :
+      {
+        backgroundColor: theme.palette.background.paper,
+        overflowX: 'hidden',
+        overflowY: 'auto',
+        width: '71px',
+        display: 'flex',
+        alignItems: 'center',
+        flexDirection: 'column'
+      }
+  ))
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
@@ -79,7 +97,7 @@ export const SideBar = () => {
   }
 
   return (
-    <SideBarContainer>
+    <SideBarContainer sx={optionStore.window.minimalInterface ? { 'margin-top': "16px" } : {  }}>
       <Observer>
         {() => (
           <DndContext
@@ -99,12 +117,12 @@ export const SideBar = () => {
       <TabAdd />
       <Box sx={{ flex: 1 }} />
 
-      <IconButton onClick={handleToggleVolume} sx={{ mb: 1 }} aria-label='toggle-volume'>
+      <IconButton onClick={handleToggleVolume} sx={optionStore.window.minimalInterface ? { margin: "0px 2px", backgroundColor: "#2E2E2E90", width: "40px", height: "40px" } : { mb: 1 }} aria-label='toggle-volume'>
         <Observer>
           {() => (gameStore.isMuted ? <VolumeOff color={'error'} /> : <VolumeUp color={'primary'} />)}
         </Observer>
       </IconButton>
-      <IconButton onClick={handleOpenOption} sx={{ mb: 1 }} aria-label='settings'>
+      <IconButton onClick={handleOpenOption} sx={optionStore.window.minimalInterface ? { margin: "0px 2px", backgroundColor: "#2E2E2E90", width: "40px", height: "40px" } : { mb: 1 }} aria-label='settings'>
         <Settings />
       </IconButton>
     </SideBarContainer>

--- a/packages/renderer/src/screens/main-screen/side-bar/tab/TabAdd.tsx
+++ b/packages/renderer/src/screens/main-screen/side-bar/tab/TabAdd.tsx
@@ -10,7 +10,7 @@ interface TabAddProps {
 }
 
 export const TabAdd = styled((props: TabAddProps) => {
-  const { gameStore } = useStores()
+  const { gameStore, optionStore } = useStores()
   const { LL } = useI18nContext()
 
   const handleAddGame = () => {
@@ -23,7 +23,7 @@ export const TabAdd = styled((props: TabAddProps) => {
   }
 
   return (
-    <div onClick={handleAddGame} className={classNames(styles.tab, props.className)}>
+    <div onClick={handleAddGame} className={classNames(optionStore.window.minimalInterface ? styles.tabMini : styles.tab, props.className)}>
       <Icon sx={{ fontSize: 24 }}>add</Icon>
     </div>
   )

--- a/packages/renderer/src/screens/main-screen/side-bar/tab/TabGame.tsx
+++ b/packages/renderer/src/screens/main-screen/side-bar/tab/TabGame.tsx
@@ -12,7 +12,7 @@ export interface TabGameProps {
 }
 
 export const TabGame = styled(({ game, className }: TabGameProps) => {
-  const { gameStore } = useStores()
+  const { gameStore, optionStore } = useStores()
   const characterIconRef = useRef<HTMLDivElement>(null)
 
   const handleClose = (event: React.MouseEvent) => {
@@ -50,7 +50,7 @@ export const TabGame = styled(({ game, className }: TabGameProps) => {
           <Tooltip title={game.characterName ?? ''} placement='right'>
             <div
               onClick={() => gameStore.selectGame(game)}
-              className={classNames(styles.tab, styles['tab-game'], className, {
+              className={classNames(optionStore.window.minimalInterface ? styles.tabMini : styles.tab, styles['tab-game'], className, {
                 focus: active,
                 notification: game.hasNotification
               })}

--- a/packages/renderer/src/screens/main-screen/side-bar/tab/tab.module.scss
+++ b/packages/renderer/src/screens/main-screen/side-bar/tab/tab.module.scss
@@ -46,3 +46,57 @@
     }
   }
 }
+
+.tabMini {
+  width: 40px;
+  height: 40px;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0px 2px;
+  border-radius: 50%;
+  line-height: 1.3;
+  font-weight: 200;
+  font-size: 28px;
+  text-align: center;
+
+  &.tab-game {
+    opacity: .7;
+    border-width: 1px;
+    border-style: solid;
+    position: relative;
+    
+    .icon-char {
+      border-radius: 100%;
+      width: 28px;
+      height: 28px;
+      display: none;
+    }
+    .icon-char > .CharacterDisplay > .Canvas {
+      height: 28px;
+      aspect-ratio: 2 / 1;
+    }
+    .tab-close {
+      display: none;
+    }
+    &:hover {
+      .tab-close {
+        display: block;
+        position: absolute;
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        top: 0px;
+        right: -6px;
+        line-height: 1;
+        background: white;
+        color: black;
+      }
+    }
+    &.notification {
+      opacity: 1;
+      animation: blink 1.5s linear infinite;
+    }
+  }
+}

--- a/packages/renderer/src/screens/option-screen/general/OptionGeneral.tsx
+++ b/packages/renderer/src/screens/option-screen/general/OptionGeneral.tsx
@@ -20,7 +20,7 @@ export const OptionGeneral = () => {
   const { appStore, optionStore } = useStores()
   const [displayRestart, setDisplayRestart] = React.useState(false)
   const { LL } = useI18nContext()
-
+  
   const handleResetGameData = () => {
     window.lindoAPI.resetGameData()
   }
@@ -75,6 +75,14 @@ export const OptionGeneral = () => {
                 label={LL.option.general.fullScreen()}
                 checked={optionStore.window.fullScreen}
                 onChange={(_, checked) => optionStore.window.setFullScreen(checked)}
+              />
+            </FormControl>
+            <FormControl fullWidth>
+              <FormControlLabel
+                control={<Checkbox />}
+                label={LL.option.general.minimalInterface()}
+                checked={optionStore.window.minimalInterface}
+                onChange={(_, checked) => optionStore.window.setMinimalInterface(checked)}
               />
             </FormControl>
             <FormControl fullWidth>

--- a/packages/shared/models/option-store/window-option/window-option.ts
+++ b/packages/shared/models/option-store/window-option/window-option.ts
@@ -12,6 +12,7 @@ export const WindowOptionModel = types
   .model('WindowOption')
   .props({
     fullScreen: types.optional(types.boolean, false),
+    minimalInterface: types.optional(types.boolean, false),
     resolution: types.optional(types.frozen<Resolution>(), {
       width: 1280,
       height: 720
@@ -27,6 +28,9 @@ export const WindowOptionModel = types
   .actions((self) => ({
     setFullScreen(value: boolean) {
       self.fullScreen = value
+    },
+    setMinimalInterface(value: boolean){
+      self.minimalInterface = value
     },
     setResolution(resolution: Resolution) {
       self.resolution = resolution


### PR DESCRIPTION
- Updated the list of user agents to include recent devices (2023). 
- Instead of completely removing user agent client hints, we keep them and use a different one for each window. 
- Add the option for a minimal interface which doesn't take horizontal space away from the game window.

Screenshot of minimal interface :
![image](https://github.com/prixe/lindo/assets/52712038/0c36e7bb-89c0-4e05-a8d0-1bad91a5fc34)

Example of user agent modification:
- window 1
![Lindo_kIXR6Il1oM](https://github.com/prixe/lindo/assets/52712038/ee050a4f-4f2b-4746-9ef9-fb4490be61e7)
- window 2
![Lindo_u62du7Fjs4](https://github.com/prixe/lindo/assets/52712038/2b28d602-0a6a-4117-a351-e81cdbd68654)

